### PR TITLE
Proposal: different approach to radiance install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,8 @@ RUN pip install -r requirements.txt
 COPY ./jobs /jobs
 
 # this didn't solve the permission issues for celery.
-# for now running everything as root. 
+# for now running everything as root.
 # RUN chown nobody: /jobs && chmod u+rwX /jobs
-
-# copy radiance libraries
-COPY ./radiance/bin /usr/local/bin
-COPY ./radiance/lib /usr/local/lib/ray
 
 # copy ladybug and honeybee libraries.
 COPY ./ladybug ./ladybug
@@ -24,5 +20,18 @@ COPY ./honeybee ./honeybee
 
 # copy all the python files for the app
 COPY ./*.py ./
+
+# copy radiance libraries
+#COPY ./radiance/bin /usr/local/bin
+#COPY ./radiance/lib /usr/local/lib/ray
+
+# Install Radiance from source
+# Avoids issue you had here with missing lib file(?)
+RUN cd /tmp \
+    && wget https://github.com/NREL/Radiance/releases/download/5.1.0/radiance-5.1.0-Linux.tar.gz \
+    && tar -xzvf radiance-5.1.0-Linux.tar.gz \
+    && cp -a radiance-5.1.0-Linux/usr/local/radiance/bin/. /usr/local/bin \
+    && cp -a radiance-5.1.0-Linux/usr/local/radiance/lib/. /usr/local/lib/ray 
+# Where do the "man" folder items go?
 
 EXPOSE 5000

--- a/test.py
+++ b/test.py
@@ -4,7 +4,7 @@ import json
 
 status_url = {}
 for i in range(25):
-    data = {'file': open('./tests/recipe.json', 'rb')}
+    data = {'file': open('./tests/test_recipe.json', 'rb')}
     response = requests.post(url='http://127.0.0.1:5000/', files=data)
     print(response.content)
     status_url[response.headers['status']] = False  # is done is false


### PR DESCRIPTION
Just had a quick test and noticed 2 bugs:

1. radiance folder in repo did not have "lib" folder (only bin and man) so proposed different install where radiance is pulled from NREL repo, unzipped and moved to correct folders. Not sure where the "man" folder goes though and use of radiance download from "source" rather than in folder in repo is just a personal preference (seems cleaner).

2. tiny bug in the test.py where the wrong file name was used. Changed it so example works.

ps: like the approach to do everything using open source (redis + celery).

pps: please feel free to remove comments I've left in the dockerfile or completely reject this proposal of radiance install from source github repo rather than from this repo.